### PR TITLE
Add 'kind' argument to parser for installation type and update versio…

### DIFF
--- a/librepythonista_py_edit/cell_edit.py
+++ b/librepythonista_py_edit/cell_edit.py
@@ -96,6 +96,15 @@ def _parser_args_add(parser: argparse.ArgumentParser) -> None:
         dest="subprocess_mode",
         default=True,
     )
+    parser.add_argument(
+        "-k",
+        "--kind",
+        help="Kind of installation (default, flatpak, snap)",
+        action="store",
+        dest="kind",
+        default="default",
+        choices=["default", "flatpak", "snap"],
+    )
 
 
 # endregion Args Parse
@@ -109,6 +118,7 @@ class RuntimeArgs:
         self.debug_mode = False
         self.socket_path = ""
         self.host = "localhost"
+        self.kind = "default"
         self.subprocess_mode = True
 
     def from_args(self, args: argparse.Namespace):
@@ -116,9 +126,13 @@ class RuntimeArgs:
         self.port = int(args.port_number)
         self.socket_path = str(args.socket_path)
         self.host = str(args.host)
+        if args.kind:
+            self.kind = str(args.kind)
         self.subprocess_mode = bool(args.subprocess_mode)
         debug_mode = str(args.debug_mode)
         self.debug_mode = debug_mode.lower() == "debug"
+        if self.socket_path.startswith("~"):
+            self.socket_path = str(Path(self.socket_path).expanduser())
 
 
 # endregion Runtime Args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librepythonista-python-editor"
-version = "0.1.6"
+version = "0.1.7"
 description = "A Python editor for LibreOffice that has the LibrePythonista extension installed."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This pull request includes changes to add a new argument for specifying the kind of installation, update the initialization logic to handle this new argument, and increment the project version. The most important changes are listed below:

Enhancements to argument parsing:

* [`librepythonista_py_edit/cell_edit.py`](diffhunk://#diff-e8aec4d4ce5368273bd9aae4b46b0d5638a6eeb90639812cea428ed563251795R99-R107): Added a new argument `--kind` to specify the kind of installation (default, flatpak, snap).

Initialization updates:

* [`librepythonista_py_edit/cell_edit.py`](diffhunk://#diff-e8aec4d4ce5368273bd9aae4b46b0d5638a6eeb90639812cea428ed563251795R121-R135): Updated the `__init__` method to include the `kind` attribute and modified the `from_args` method to handle the new `--kind` argument.

Version increment:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Incremented the project version from `0.1.6` to `0.1.7`.